### PR TITLE
fix events to have title and database to support time

### DIFF
--- a/clamor/src/main/java/com/revature/controllers/GroupController.java
+++ b/clamor/src/main/java/com/revature/controllers/GroupController.java
@@ -203,7 +203,7 @@ public class GroupController {
 		
 		Usergroup ug = (usergroupService.findByUserIdAndGroupId(event.getCreator().getId(), groupId)).get(0);
 		if (ug.getRole().getRoleName().contentEquals("member") || ug.getRole().getRoleName().equals("organizer")) {
-			eventService.createEvent(event.getCreator().getId(), groupId, event.getDescription(), event.getDatePosted(), event.getDateOf(), event.isLive());
+			eventService.createEvent(event.getCreator().getId(), groupId, event.getTitle(), event.getDescription(), event.getDatePosted(), event.getDateOf(), event.isLive());
 			return true;
 		}
 		

--- a/clamor/src/main/java/com/revature/repositories/EventDao.java
+++ b/clamor/src/main/java/com/revature/repositories/EventDao.java
@@ -17,7 +17,7 @@ public interface EventDao extends JpaRepository<Event, Integer> {
 	List<Event> findByGroupIdId(int groupId);
 	
 	@Modifying
-	@Query(value = "INSERT INTO clamor.event (creator, group_id, description, date_posted, date_of, live) VALUES (:usergroupId, :groupId, :description, :datePosted, :dateOf, :live)", nativeQuery = true)
+	@Query(value = "INSERT INTO clamor.event (creator, group_id, title, description, date_posted, date_of, live) VALUES (:usergroupId, :groupId, :title, :description, :datePosted, :dateOf, :live)", nativeQuery = true)
 	@Transactional
-	void createEvent(@Param("usergroupId") int usergroupId, @Param("groupId") int groupId, @Param("description") String description, @Param("datePosted") Date datePosted, @Param("dateOf") Date dateOf, @Param("live") boolean live);
+	void createEvent(@Param("usergroupId") int usergroupId, @Param("groupId") int groupId, @Param("title") String title, @Param("description") String description, @Param("datePosted") Date datePosted, @Param("dateOf") Date dateOf, @Param("live") boolean live);
 }

--- a/clamor/src/main/java/com/revature/services/EventService.java
+++ b/clamor/src/main/java/com/revature/services/EventService.java
@@ -12,7 +12,7 @@ public interface EventService {
 	
 	List<Event> findByGroupId(int groupId);
 	
-	void createEvent(int usergroupId, int groupId, String description, Date datePosted, Date dateOf, boolean live);
+	void createEvent(int usergroupId, int groupId, String title, String description, Date datePosted, Date dateOf, boolean live);
 	
 	Event save(Event event);
 	

--- a/clamor/src/main/java/com/revature/services/EventServiceImpl.java
+++ b/clamor/src/main/java/com/revature/services/EventServiceImpl.java
@@ -44,10 +44,10 @@ public class EventServiceImpl implements EventService {
 	}
 
 	@Override
-	public void createEvent(int usergroupId, int groupId, String description, Date datePosted, Date dateOf,
+	public void createEvent(int usergroupId, int groupId, String title, String description, Date datePosted, Date dateOf,
 			boolean live) {
 
-		eventDao.createEvent(usergroupId, groupId, description, datePosted, dateOf, live);
+		eventDao.createEvent(usergroupId, groupId, title, description, datePosted, dateOf, live);
 	}
 	
 	@Override

--- a/database.sql
+++ b/database.sql
@@ -49,7 +49,7 @@ create table user_group(
 create table group_message(
 	id serial primary key,
 	author int references user_group on delete cascade,
-	date_created date default now(),
+	date_created timestamp default now(),
 	"content" text not null
 );
 
@@ -59,8 +59,8 @@ create table "event"(
 	group_id int references "group" on delete cascade,
 	title text not null,
 	description text not null,
-	date_posted date default now(),
-	date_of date not null,
+	date_posted timestamp default now(),
+	date_of timestamp not null,
 	live boolean default true
 );
 
@@ -75,7 +75,7 @@ create table direct_message(
 	id serial primary key,
 	friends int references friending on delete cascade,
 	"content" text not null,
-	sent_date date default now()
+	sent_date timestamp default now()
 );
 
 create table invitation(


### PR DESCRIPTION
Title area was still missing from some parts of the creation process for posting things, so fixed that, and I changed most date types in the database to timestamp instead because we need to know date AND time for a lot of things (like events, messages, etc), but birthdates can remain as dates because nobody really cares what time you were born (harsh, but true).